### PR TITLE
AfterEach plus clean mocks and spies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ deploy:
     on:
       tags: false
       all_branches: true
-      condition: "$TRAVIS_BRANCH != master"
+      condition: "$TRAVIS_BRANCH == master"
   # deploy master to production
   - provider: script
     script: bash ./deploy.sh production

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Stubs treat even the async nature of nginx - ran on demand
 
 ### mock(...) - Mocking
 
-Mock whatever methods you want
+Mock whatever methods you want. Mocks are reset after each test. And loose
+whatever stubbing you did. That is why if any stub is needed than it should be
+declared at beforeEach level or test level.
 
 ``` 
     local classToMock = mock("path.to.class", {"method1", "method2"})

--- a/dist/luarocks/mocka-1.0.1-1.rockspec
+++ b/dist/luarocks/mocka-1.0.1-1.rockspec
@@ -16,8 +16,6 @@ build = {
    platforms = {
       haiku = {
          modules = {
-            ["luacov.cobertura.luatoxml"] = "luacov-cobertura/luacov/cobertura/luatoxml.lua",
-            ["luacov.reporter.cobertura"] = "luacov-cobertura/luacov/reporter/cobertura.lua",
             mocka = "src/main/lua/com/adobe/test/framework/Mocka.lua",
             ["mocka.debugger"] = "src/main/lua/com/adobe/test/framework/debugger.lua",
             ["mocka.default_mocks"] = "src/main/lua/com/adobe/test/framework/default_mocks.lua",
@@ -30,8 +28,6 @@ build = {
       },
       macosx = {
          modules = {
-            ["luacov.cobertura.luatoxml"] = "luacov-cobertura/luacov/cobertura/luatoxml.lua",
-            ["luacov.reporter.cobertura"] = "luacov-cobertura/luacov/reporter/cobertura.lua",
             mocka = "src/main/lua/com/adobe/test/framework/Mocka.lua",
             ["mocka.debugger"] = "src/main/lua/com/adobe/test/framework/debugger.lua",
             ["mocka.default_mocks"] = "src/main/lua/com/adobe/test/framework/default_mocks.lua",
@@ -44,8 +40,6 @@ build = {
       },
       mingw32 = {
          modules = {
-            ["luacov.cobertura.luatoxml"] = "luacov-cobertura/luacov/cobertura/luatoxml.lua",
-            ["luacov.reporter.cobertura"] = "luacov-cobertura/luacov/reporter/cobertura.lua",
             mocka = "src/main/lua/com/adobe/test/framework/Mocka.lua",
             ["mocka.debugger"] = "src/main/lua/com/adobe/test/framework/debugger.lua",
             ["mocka.default_mocks"] = "src/main/lua/com/adobe/test/framework/default_mocks.lua",
@@ -58,8 +52,6 @@ build = {
       },
       unix = {
          modules = {
-            ["luacov.cobertura.luatoxml"] = "luacov-cobertura/luacov/cobertura/luatoxml.lua",
-            ["luacov.reporter.cobertura"] = "luacov-cobertura/luacov/reporter/cobertura.lua",
             mocka = "src/main/lua/com/adobe/test/framework/Mocka.lua",
             ["mocka.debugger"] = "src/main/lua/com/adobe/test/framework/debugger.lua",
             ["mocka.default_mocks"] = "src/main/lua/com/adobe/test/framework/default_mocks.lua",
@@ -72,8 +64,6 @@ build = {
       },
       win32 = {
          modules = {
-            ["luacov.cobertura.luatoxml"] = "luacov-cobertura/luacov/cobertura/luatoxml.lua",
-            ["luacov.reporter.cobertura"] = "luacov-cobertura/luacov/reporter/cobertura.lua",
             mocka = "src/main/lua/com/adobe/test/framework/Mocka.lua",
             ["mocka.debugger"] = "src/main/lua/com/adobe/test/framework/debugger.lua",
             ["mocka.default_mocks"] = "src/main/lua/com/adobe/test/framework/default_mocks.lua",

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -z "${LUAROCKS_FILE}" ]; then
+if [ ! -z "${LUAROCKS_FILE}" ]; then
     sudo luarocks make ${LUAROCKS_FILE}
 fi
 

--- a/src/main/lua/com/adobe/test/framework/Mocka.lua
+++ b/src/main/lua/com/adobe/test/framework/Mocka.lua
@@ -394,14 +394,14 @@ function test(description, fn, assertFail)
     ti.time = elapsed
 
     if not status and not assertFail then
-        print("\t\t " .. description .. " ----- FAIL ")
+        print("\t\t " .. description .. " ----- FAIL : " .. tostring(elapsed) .. "s")
         local callingFunction = debug.getinfo(2)
-        print(string.format("%s in %s : %s", result, callingFunction.short_src,
-            callingFunction.currentline))
+        print(string.format("%s in %s : %s - trace: %s", result, callingFunction.short_src,
+            callingFunction.currentline, debug.traceback()))
         mockaStats.noNOK = mockaStats.noNOK + 1;
         si.noNOK = si.noNOK + 1
     else
-        print("\t\t " .. description .. " ----- SUCCESS ")
+        print("\t\t " .. description .. " ----- SUCCESS : " .. tostring(elapsed) .. "s")
         mockaStats.noOK = mockaStats.noOK + 1;
         si.noOK = si.noOK + 1
     end

--- a/src/main/lua/com/adobe/test/framework/Mocka.lua
+++ b/src/main/lua/com/adobe/test/framework/Mocka.lua
@@ -73,10 +73,24 @@ local function _compare(t1, t2)
     return true
 end
 
+--- should be here because of using global mocka definitions
+local default_mocks = require("mocka.default_mocks")
+
+function mockNgx(conf)
+    if not mockaStats.isNgx then
+        if not conf then
+            ngx = default_mocks.makeNgxMock()
+        else
+            ngx =  conf
+        end
+    end
+end
+
 function clearTest()
     spies = {}
     mirror = {}
     mocks = {}
+    mockNgx()
 end
 
 ---
@@ -573,15 +587,5 @@ function assertNotEquals(t1, t2)
     end
 end
 
---- should be here because of using global mocka definitions
-local default_mocks = require("mocka.default_mocks")
-
-function mockNgx(conf)
-    if not conf then
-        ngx = default_mocks.makeNgxMock()
-    else
-        ngx =  conf
-    end
-end
 
 

--- a/src/main/lua/com/adobe/test/framework/Mocka.lua
+++ b/src/main/lua/com/adobe/test/framework/Mocka.lua
@@ -88,11 +88,6 @@ function mockNgx(conf)
     end
 end
 
-function clearTest()
-    mocks = {}
-    lazy_spies = {}
-    mockNgx()
-end
 
 function clearSuite()
     beforeFn = nil
@@ -227,6 +222,13 @@ local function __makeSpy(path)
             end
         end
     end
+end
+
+function clearTest()
+    mocks = {}
+    lazy_spies = {}
+    __makeSpy()
+    mockNgx()
 end
 
 --- Converts a table to a string

--- a/src/main/lua/com/adobe/test/framework/Mocka.lua
+++ b/src/main/lua/com/adobe/test/framework/Mocka.lua
@@ -226,8 +226,17 @@ end
 
 function clearTest()
     mocks = {}
-    lazy_spies = {}
-    __makeSpy()
+
+    if isNgx then
+        -- in ngx context spies must be preserved but reset (integration tests)
+        lazy_spies = {}
+        __makeSpy()
+    else
+        -- in non ngx context - unit tests spies and mirrors must be reset everything should be fresh
+        spies = {}
+        mirror = {}
+        lazy_spies = {}
+    end
     mockNgx()
 end
 

--- a/src/main/lua/com/adobe/test/framework/Mocka.lua
+++ b/src/main/lua/com/adobe/test/framework/Mocka.lua
@@ -230,9 +230,15 @@ local function __makeSpy(path)
 end
 
 function clearTest()
-    __makeSpy()
+    lazy_spies = {}
     mocks = {}
+    __makeSpy()
     mockNgx()
+end
+
+function clearSuite()
+    beforeFn = nil
+    afterFn = nil
 end
 
 

--- a/src/main/lua/com/adobe/test/framework/Mocka.lua
+++ b/src/main/lua/com/adobe/test/framework/Mocka.lua
@@ -89,9 +89,8 @@ function mockNgx(conf)
 end
 
 function clearTest()
-    spies = {}
-    mirror = {}
     mocks = {}
+    lazy_spies = {}
     mockNgx()
 end
 

--- a/src/main/lua/com/adobe/test/framework/Mocka.lua
+++ b/src/main/lua/com/adobe/test/framework/Mocka.lua
@@ -396,8 +396,8 @@ function test(description, fn, assertFail)
     if not status and not assertFail then
         print("\t\t " .. description .. " ----- FAIL : " .. tostring(elapsed) .. "s")
         local callingFunction = debug.getinfo(2)
-        print(string.format("%s in %s : %s - trace: %s", result, callingFunction.short_src,
-            callingFunction.currentline, debug.traceback()))
+        print(string.format("%s in %s : %s", result, callingFunction.short_src,
+            callingFunction.currentline))
         mockaStats.noNOK = mockaStats.noNOK + 1;
         si.noNOK = si.noNOK + 1
     else

--- a/src/main/lua/com/adobe/test/framework/Mocka.lua
+++ b/src/main/lua/com/adobe/test/framework/Mocka.lua
@@ -79,7 +79,7 @@ end
 local default_mocks = require("mocka.default_mocks")
 
 function mockNgx(conf)
-    if not mockaStats.isNgx then
+    if not isNgx then
         if not conf then
             ngx = default_mocks.makeNgxMock()
         else

--- a/src/main/lua/com/adobe/test/framework/Mocka.lua
+++ b/src/main/lua/com/adobe/test/framework/Mocka.lua
@@ -22,6 +22,9 @@ local mirror = {}
 -- before each function rememberer
 local beforeFn;
 
+-- after each function rememberer
+local afterFn;
+
 -- stats for the framework needed for outputing results
 mockaStats = {
     suites = {},
@@ -68,6 +71,10 @@ local function _compare(t1, t2)
         if v1 == nil or not _compare(v1, v2) then return false end
     end
     return true
+end
+
+local function clearTest()
+    spies = {}
 end
 
 ---
@@ -297,6 +304,15 @@ function beforeEach(fn)
     beforeFn = fn
 end
 
+
+---
+-- @param fn {function} - the function to be ran afterEach Test
+-- Saves the function in a variable in order to call it before each test for a suite
+---
+function afterEach(fn)
+    afterFn = fn
+end
+
 ---
 -- @param description  {string}
 -- @param ... {optional}
@@ -377,6 +393,12 @@ function test(description, fn, assertFail)
     end
     mockaStats.no = mockaStats.no + 1;
     si.no = si.no + 1
+
+    if (afterFn ~= nil) then
+        pcall(afterFn)
+    end
+
+    clearTest()
 end
 
 ---
@@ -568,3 +590,4 @@ function clearMocks(inNgx)
         ngx = default_mocks.makeNgxMock()
     end
 end
+

--- a/src/main/lua/com/adobe/test/suites/run_ngx_tests.lua
+++ b/src/main/lua/com/adobe/test/suites/run_ngx_tests.lua
@@ -73,7 +73,7 @@ local run_tests = function(tests)
 
     mockaStats.time = elapsedFullTime
     print("\n Tests: " .. mockaStats.no .. " Pass: " .. mockaStats.noOK .. " Fail: " .. mockaStats.noNOK ..
-            " Ignored : " .. mockaStats.noIgnored .. " Duration: " .. tostring(mockaStats.time))
+            " Ignored : " .. mockaStats.noIgnored .. " Duration: " .. tostring(mockaStats.time) .. "s")
 
     local result = xmlOutput()
     return result

--- a/src/main/lua/com/adobe/test/suites/run_ngx_tests.lua
+++ b/src/main/lua/com/adobe/test/suites/run_ngx_tests.lua
@@ -45,6 +45,7 @@ local xmlOutput = function()
 end
 
 local run_tests = function(tests)
+    mockaStats.isNgx = true
     resetStats()
     local startFullTime = os.clock()
     for i, module in ipairs(tests) do

--- a/src/main/lua/com/adobe/test/suites/run_ngx_tests.lua
+++ b/src/main/lua/com/adobe/test/suites/run_ngx_tests.lua
@@ -58,7 +58,7 @@ local run_tests = function(tests)
             tests = {},
             time = 0
         })
-        clearMocks(true)
+
         local startTime = os.clock()
         require(module)()
         local elapsed = os.clock() - startTime

--- a/src/main/lua/com/adobe/test/suites/run_ngx_tests.lua
+++ b/src/main/lua/com/adobe/test/suites/run_ngx_tests.lua
@@ -48,6 +48,7 @@ local run_tests = function(tests)
     resetStats()
     local startFullTime = os.clock()
     for i, module in ipairs(tests) do
+        clearSuite()
         print("\n\t Running " .. module .. '\n\t -----------------------------------------------------------------------\n')
         table.insert(mockaStats.suites, {
             name = module,

--- a/src/main/lua/com/adobe/test/suites/run_ngx_tests.lua
+++ b/src/main/lua/com/adobe/test/suites/run_ngx_tests.lua
@@ -45,7 +45,6 @@ local xmlOutput = function()
 end
 
 local run_tests = function(tests)
-    mockaStats.isNgx = true
     resetStats()
     local startFullTime = os.clock()
     for i, module in ipairs(tests) do

--- a/src/main/lua/com/adobe/test/suites/run_tests.lua
+++ b/src/main/lua/com/adobe/test/suites/run_tests.lua
@@ -47,6 +47,7 @@ local xmlOutput = function()
 end
 
 local run_tests = function(tests)
+    mockaStats.isNgx = false
     resetStats()
     local startFullTime = os.clock()
     for i, module in ipairs(tests) do
@@ -60,7 +61,6 @@ local run_tests = function(tests)
             tests = {},
             time = 0
         })
-        mockNgx()
         local startTime = os.clock()
         require(module)
         local elapsed = os.clock() - startTime

--- a/src/main/lua/com/adobe/test/suites/run_tests.lua
+++ b/src/main/lua/com/adobe/test/suites/run_tests.lua
@@ -60,7 +60,7 @@ local run_tests = function(tests)
             tests = {},
             time = 0
         })
-        clearMocks()
+        mockNgx()
         local startTime = os.clock()
         require(module)
         local elapsed = os.clock() - startTime

--- a/src/main/lua/com/adobe/test/suites/run_tests.lua
+++ b/src/main/lua/com/adobe/test/suites/run_tests.lua
@@ -74,7 +74,7 @@ local run_tests = function(tests)
 
     mockaStats.time = elapsedFullTime
     print("\n Tests: " .. mockaStats.no .. " Pass: " .. mockaStats.noOK .. " Fail: " .. mockaStats.noNOK ..
-            " Ignored : " .. mockaStats.noIgnored .. " Duration: " .. tostring(mockaStats.time))
+            " Ignored : " .. mockaStats.noIgnored .. " Duration: " .. tostring(mockaStats.time) .. "s")
 
     xmlOutput()
     if(mockaStats.noNOK > 0) then

--- a/src/main/lua/com/adobe/test/suites/run_tests.lua
+++ b/src/main/lua/com/adobe/test/suites/run_tests.lua
@@ -47,10 +47,10 @@ local xmlOutput = function()
 end
 
 local run_tests = function(tests)
-    mockaStats.isNgx = false
     resetStats()
     local startFullTime = os.clock()
     for i, module in ipairs(tests) do
+        clearSuite()
         print("\n\t Running " .. module .. '\n\t -----------------------------------------------------------------------\n')
         table.insert(mockaStats.suites, {
             name = module,


### PR DESCRIPTION
## Description

* added support for afterEach
* cleanup after each test ( default afterEach cleanup )
* cleanup after each suite - beforeEach must be reset
* separate resets between integration tests / unit tests (ngx and non ngx)
* the changes alter the model of having mocks declared above the test
* all mocks and spies must be declared in beforeEach
* updated docs

Fixes #28, #37, #49

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have signed the [Adobe CLA](http://opensource.adobe.com/cla.html)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
