### PR TITLE
AfterEach plus clean mocks and spies (#52)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ deploy:
     on:
       tags: false
       all_branches: true
-      condition: "$TRAVIS_BRANCH != master"
+      condition: "$TRAVIS_BRANCH == master"
   # deploy master to production
   - provider: script
     script: bash ./deploy.sh production

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Stubs treat even the async nature of nginx - ran on demand
 
 ### mock(...) - Mocking
 
-Mock whatever methods you want
+Mock whatever methods you want. Mocks are reset after each test. And loose
+whatever stubbing you did. That is why if any stub is needed than it should be
+declared at beforeEach level or test level.
 
 ``` 
     local classToMock = mock("path.to.class", {"method1", "method2"})

--- a/dist/luarocks/mocka-1.0.1-1.rockspec
+++ b/dist/luarocks/mocka-1.0.1-1.rockspec
@@ -16,8 +16,6 @@ build = {
    platforms = {
       haiku = {
          modules = {
-            ["luacov.cobertura.luatoxml"] = "luacov-cobertura/luacov/cobertura/luatoxml.lua",
-            ["luacov.reporter.cobertura"] = "luacov-cobertura/luacov/reporter/cobertura.lua",
             mocka = "src/main/lua/com/adobe/test/framework/Mocka.lua",
             ["mocka.debugger"] = "src/main/lua/com/adobe/test/framework/debugger.lua",
             ["mocka.default_mocks"] = "src/main/lua/com/adobe/test/framework/default_mocks.lua",
@@ -30,8 +28,6 @@ build = {
       },
       macosx = {
          modules = {
-            ["luacov.cobertura.luatoxml"] = "luacov-cobertura/luacov/cobertura/luatoxml.lua",
-            ["luacov.reporter.cobertura"] = "luacov-cobertura/luacov/reporter/cobertura.lua",
             mocka = "src/main/lua/com/adobe/test/framework/Mocka.lua",
             ["mocka.debugger"] = "src/main/lua/com/adobe/test/framework/debugger.lua",
             ["mocka.default_mocks"] = "src/main/lua/com/adobe/test/framework/default_mocks.lua",
@@ -44,8 +40,6 @@ build = {
       },
       mingw32 = {
          modules = {
-            ["luacov.cobertura.luatoxml"] = "luacov-cobertura/luacov/cobertura/luatoxml.lua",
-            ["luacov.reporter.cobertura"] = "luacov-cobertura/luacov/reporter/cobertura.lua",
             mocka = "src/main/lua/com/adobe/test/framework/Mocka.lua",
             ["mocka.debugger"] = "src/main/lua/com/adobe/test/framework/debugger.lua",
             ["mocka.default_mocks"] = "src/main/lua/com/adobe/test/framework/default_mocks.lua",
@@ -58,8 +52,6 @@ build = {
       },
       unix = {
          modules = {
-            ["luacov.cobertura.luatoxml"] = "luacov-cobertura/luacov/cobertura/luatoxml.lua",
-            ["luacov.reporter.cobertura"] = "luacov-cobertura/luacov/reporter/cobertura.lua",
             mocka = "src/main/lua/com/adobe/test/framework/Mocka.lua",
             ["mocka.debugger"] = "src/main/lua/com/adobe/test/framework/debugger.lua",
             ["mocka.default_mocks"] = "src/main/lua/com/adobe/test/framework/default_mocks.lua",
@@ -72,8 +64,6 @@ build = {
       },
       win32 = {
          modules = {
-            ["luacov.cobertura.luatoxml"] = "luacov-cobertura/luacov/cobertura/luatoxml.lua",
-            ["luacov.reporter.cobertura"] = "luacov-cobertura/luacov/reporter/cobertura.lua",
             mocka = "src/main/lua/com/adobe/test/framework/Mocka.lua",
             ["mocka.debugger"] = "src/main/lua/com/adobe/test/framework/debugger.lua",
             ["mocka.default_mocks"] = "src/main/lua/com/adobe/test/framework/default_mocks.lua",

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -z "${LUAROCKS_FILE}" ]; then
+if [ ! -z "${LUAROCKS_FILE}" ]; then
     sudo luarocks make ${LUAROCKS_FILE}
 fi
 

--- a/src/main/lua/com/adobe/test/suites/run_ngx_tests.lua
+++ b/src/main/lua/com/adobe/test/suites/run_ngx_tests.lua
@@ -48,6 +48,7 @@ local run_tests = function(tests)
     resetStats()
     local startFullTime = os.clock()
     for i, module in ipairs(tests) do
+        clearSuite()
         print("\n\t Running " .. module .. '\n\t -----------------------------------------------------------------------\n')
         table.insert(mockaStats.suites, {
             name = module,
@@ -58,7 +59,7 @@ local run_tests = function(tests)
             tests = {},
             time = 0
         })
-        clearMocks(true)
+
         local startTime = os.clock()
         require(module)()
         local elapsed = os.clock() - startTime
@@ -72,7 +73,7 @@ local run_tests = function(tests)
 
     mockaStats.time = elapsedFullTime
     print("\n Tests: " .. mockaStats.no .. " Pass: " .. mockaStats.noOK .. " Fail: " .. mockaStats.noNOK ..
-            " Ignored : " .. mockaStats.noIgnored .. " Duration: " .. tostring(mockaStats.time))
+            " Ignored : " .. mockaStats.noIgnored .. " Duration: " .. tostring(mockaStats.time) .. "s")
 
     local result = xmlOutput()
     return result

--- a/src/main/lua/com/adobe/test/suites/run_tests.lua
+++ b/src/main/lua/com/adobe/test/suites/run_tests.lua
@@ -50,6 +50,7 @@ local run_tests = function(tests)
     resetStats()
     local startFullTime = os.clock()
     for i, module in ipairs(tests) do
+        clearSuite()
         print("\n\t Running " .. module .. '\n\t -----------------------------------------------------------------------\n')
         table.insert(mockaStats.suites, {
             name = module,
@@ -60,7 +61,6 @@ local run_tests = function(tests)
             tests = {},
             time = 0
         })
-        clearMocks()
         local startTime = os.clock()
         require(module)
         local elapsed = os.clock() - startTime
@@ -74,7 +74,7 @@ local run_tests = function(tests)
 
     mockaStats.time = elapsedFullTime
     print("\n Tests: " .. mockaStats.no .. " Pass: " .. mockaStats.noOK .. " Fail: " .. mockaStats.noNOK ..
-            " Ignored : " .. mockaStats.noIgnored .. " Duration: " .. tostring(mockaStats.time))
+            " Ignored : " .. mockaStats.noIgnored .. " Duration: " .. tostring(mockaStats.time) .. "s")
 
     xmlOutput()
     if(mockaStats.noNOK > 0) then


### PR DESCRIPTION
* afterEach support

* mocks and spies reset after each test

* resetting after each test

* no more pushing dockers

* removed unnecessary file

* more logging

* trace is irelevant

* better rockspecs

* running inside ngx context

* better encapsulation

* better encapsulation

* refactoring code

* better ref of isNgx

* correct clear test

* remake spies after test

* separation between unit tests and integration tests

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] I have signed the [Adobe CLA](http://opensource.adobe.com/cla.html)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
